### PR TITLE
Hack: Fix TF crash by deleting libtfkernel_sobol_op.so

### DIFF
--- a/AlphaFold2_representations.ipynb
+++ b/AlphaFold2_representations.ipynb
@@ -119,6 +119,8 @@
         "    os.system(\"pip install --no-warn-conflicts --upgrade dm-haiku==0.0.10 'jax[cuda12_pip]'==0.3.25 -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html\")\n",
         "  os.system(\"ln -s /usr/local/lib/python3.*/dist-packages/colabfold colabfold\")\n",
         "  os.system(\"ln -s /usr/local/lib/python3.*/dist-packages/alphafold alphafold\")\n",
+        "  # hack to fix TF crash\n",
+        "  os.system(\"rm -f /usr/local/lib/python3.*/dist-packages/tensorflow/core/kernels/libtfkernel_sobol_op.so\")\n",
         "  os.system(\"touch COLABFOLD_READY\")\n",
         "\n",
         "if USE_AMBER or USE_TEMPLATES:\n",


### PR DESCRIPTION
Implement fix from upstream colabfold (c3e8ab0) to avoid tf kernel error:

```python
RuntimeError: jax.tools.colab_tpu.setup_tpu() was required for older JAX versions running on older generations of TPUs, and should no longer be used.


During handling of the above exception, another exception occurred:

NotFoundError                             Traceback (most recent call last)

[/usr/local/lib/python3.12/dist-packages/tensorflow/python/framework/load_library.py](https://localhost:8080/#) in load_library(library_location)
    149 
    150     for lib in kernel_libraries:
--> 151       py_tf.TF_LoadLibrary(lib)
    152 
    153   else:

NotFoundError: /usr/local/lib/python3.12/dist-packages/tensorflow/core/kernels/libtfkernel_sobol_op.so: undefined symbol: _ZN10tensorflow15TensorShapeBaseINS_11TensorShapeEEC2EN4absl12lts_202308024SpanIKlEE

```